### PR TITLE
[Feature] Track stack memory consumption

### DIFF
--- a/karel.cpp
+++ b/karel.cpp
@@ -241,7 +241,6 @@ std::optional<Instruction> ParseInstruction(const json::ListValue& value) {
 struct StackFrame {
   int32_t pc;
   size_t param_sp;
-  size_t param_count;
   size_t sp;
 };
 
@@ -321,7 +320,6 @@ RunResult Run(const std::vector<Instruction>& program, Runtime* runtime) {
           StackFrame{
             pc, 
             expression_stack.size() - 1,
-            param_count,
             expression_stack.size() - param_count
             }
         );
@@ -338,8 +336,9 @@ RunResult Run(const std::vector<Instruction>& program, Runtime* runtime) {
         if (function_stack.empty())
           return RunResult::OK;
         StackFrame& frame = function_stack.top();
-        pc = frame.pc;        
-        runtime->stack_memory -= frame.param_count == 0 ? 1 : frame.param_count;
+        pc = frame.pc;
+        size_t param_count = (frame.param_sp + 1) - frame.sp;
+        runtime->stack_memory -= param_count == 0 ? 1 : param_count;
         if (expression_stack.size() > frame.sp)
           expression_stack.resize(frame.sp);
         function_stack.pop();

--- a/karel.h
+++ b/karel.h
@@ -92,6 +92,7 @@ struct Runtime {
   size_t left_count = 0;
   size_t leavebuzzer_count = 0;
   size_t pickbuzzer_count = 0;
+  size_t stack_memory = 0;
 
   size_t width = 100;
   size_t height = 100;

--- a/tests/test_karel.cpp
+++ b/tests/test_karel.cpp
@@ -293,3 +293,32 @@ TEST_F(TestKarel, CODE_PARSE) {
   // ASSERT_EQ(program.value(), expected)<< "Program output is not what it was expected";
 
 }
+
+
+
+TEST_F(TestKarel, STACK_MEMORY_IS_ZERO) {
+  std::vector<karel::Instruction> program = {
+    {karel::Opcode::LOAD, 0},//0
+    {karel::Opcode::CALL, 3},//1
+    {karel::Opcode::HALT},//2
+    {karel::Opcode::LOAD, 5},//3
+    {karel::Opcode::LOAD, 0},//4
+    {karel::Opcode::LOAD, 2},//5
+    {karel::Opcode::CALL, 8},//6
+    {karel::Opcode::RET},//7
+    {karel::Opcode::PARAM, 1},//8
+    {karel::Opcode::PARAM, 0},//9
+    {karel::Opcode::LTE},//10
+    {karel::Opcode::NOT},//11
+    {karel::Opcode::JZ,5},//12
+    {karel::Opcode::PARAM, 1},//13
+    {karel::Opcode::PARAM,0},//14
+    {karel::Opcode::INC,1},//15
+    {karel::Opcode::LOAD, 2},//16
+    {karel::Opcode::CALL, 8},//17
+    {karel::Opcode::RET},//18
+  };
+  auto result = karel::Run(program,runtime);
+  EXPECT_EQ(result, karel::RunResult::OK) << "Run did not end in OK status";
+  EXPECT_EQ(runtime->stack_memory, 0) << "STACK memory did not returned to zero";
+}


### PR DESCRIPTION
A call consume max(1, |arguments|) memory

Fixes #2 