### PR TITLE
[Feature] Add more line options

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "linux-gcc-x64",
+            "configurationProvider": "ms-vscode.cmake-tools"
+        }
+    ],
+    "version": 4
+}

--- a/main.cpp
+++ b/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char* argv[]) {
   };
   std::string expected_version = "";
   std::optional<std::string> output_file;
+  std::optional<std::string> input_file;
   int opt;
   while ((opt = getopt_long(argc, argv, "vd:i:o:e:", long_options, nullptr)) != -1) {
       switch (opt) {
@@ -99,11 +100,9 @@ int main(int argc, char* argv[]) {
               dump_result = std::string_view(optarg) == "world";
               break;
           case 'i':
-              // TODO: Implement this
-              // input_file = optarg;
+              input_file = optarg;
               break;
           case 'o':
-              // TODO: Implement this
               output_file = optarg;
               break;
           case 'e':
@@ -132,8 +131,16 @@ int main(int argc, char* argv[]) {
       reinterpret_cast<const char*>(program_str.data()), program_str.size()));
   if (!program)
     return -1;
+  int input_fd = STDIN_FILENO;
+  if (input_file) {
+        input_fd = open(input_file->c_str(), O_RDONLY);
+        if (input_fd == -1) {
+            perror("Error opening file");
+            return 1;
+        }
+    }
 
-  auto world = karel::World::Parse(STDIN_FILENO);
+  auto world = karel::World::Parse(input_fd);
   if (!world)
     return -1;
 
@@ -192,6 +199,9 @@ int main(int argc, char* argv[]) {
 
   if (output_fd != STDOUT_FILENO) {
     close(output_fd);
+  }
+  if (input_fd != STDIN_FILENO) {
+    close(input_fd);
   }
 
   return static_cast<int32_t>(result);

--- a/main.cpp
+++ b/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
                   Usage(argv[0]);
                   return 1;
               }
-              dump_result = std::string_view(optarg) == "world";
+              dump_result = std::string_view(optarg) == "result";
               break;
           case 'i':
               input_file = optarg;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <getopt.h>
 
 #include <algorithm>
 #include <memory>
@@ -55,40 +56,75 @@ std::vector<uint8_t> ReadFully(int fd) {
 
 }  // namespace
 
+
+constexpr const char* PROGRAM_VERSION = "2.3.0";
+
+bool CheckVersion(const std::string& expected_version) {
+    std::istringstream prog_stream(PROGRAM_VERSION);
+    std::istringstream expect_stream(expected_version);
+    std::string prog_major, prog_minor, expect_major, expect_minor;
+
+    std::getline(prog_stream, prog_major, '.');
+    std::getline(prog_stream, prog_minor, '.');
+    std::getline(expect_stream, expect_major, '.');
+    std::getline(expect_stream, expect_minor, '.');
+
+    return prog_major == expect_major && prog_minor == expect_minor;
+}
+
 int main(int argc, char* argv[]) {
-  bool dump_result = true;
-
-  for (int i = 1; i < argc; ++i) {
-    std::string_view arg = argv[i];
-    if (arg.find(kFlagPrefix) != 0)
-      continue;
-    arg.remove_prefix(kFlagPrefix.size());
-
-    if (arg.find(kDumpFlagPrefix) == 0) {
-      arg.remove_prefix(kDumpFlagPrefix.size());
-      if (arg == "world")
-        dump_result = false;
-      else if (arg == "result")
-        dump_result = true;
-      else
-        Usage(argv[0]);
-    } else {
-      Usage(argv[0]);
-    }
-
-    // Shift all arguments by one.
-    --argc;
-    for (int j = i; j < argc; ++j)
-      argv[j] = argv[j + 1];
-    --i;
+  bool dump_result = true;  
+  struct option long_options[] = {
+      {"version", no_argument, nullptr, 'v'},
+      {"dump", required_argument, nullptr, 'd'},
+      {"input", required_argument, nullptr, 'i'},
+      {"output", required_argument, nullptr, 'o'},
+      {"expect-version", required_argument, nullptr, 'e'},
+      {nullptr, 0, nullptr, 0} // End of options
+  };
+  std::string expected_version = "";
+  std::optional<std::string> output_file;
+  int opt;
+  while ((opt = getopt_long(argc, argv, "vd:i:o:e:", long_options, nullptr)) != -1) {
+      switch (opt) {
+          case 'v':
+              LOG(INFO) << "Version: " << PROGRAM_VERSION << "\n";
+              return 0;
+          case 'd':
+              if (std::string_view(optarg) != "world" && std::string_view(optarg) != "result") {
+                  LOG(ERROR) << "Error: Invalid dump option. Use 'world' or 'result'.\n";
+                  Usage(argv[0]);
+                  return 1;
+              }
+              dump_result = std::string_view(optarg) == "world";
+              break;
+          case 'i':
+              // TODO: Implement this
+              // input_file = optarg;
+              break;
+          case 'o':
+              // TODO: Implement this
+              output_file = optarg;
+              break;
+          case 'e':
+              expected_version = optarg;
+              if (!CheckVersion(expected_version)) {
+                  LOG(ERROR) << "Error: Version mismatch. Expected: " << expected_version
+                            << ", Found: " << PROGRAM_VERSION << "\n";
+                  return 2;
+              }
+              break;
+          default:
+              Usage(argv[0]);
+      }
   }
 
-  if (argc < 2)
+  if (optind >= argc || argc < 2) {
     Usage(argv[0]);
-
-  ScopedFD program_fd(open(argv[1], O_RDONLY));
+  }
+  ScopedFD program_fd(open(argv[optind], O_RDONLY));
   if (!program_fd) {
-    PLOG(ERROR) << "Failed to open " << argv[1];
+    PLOG(ERROR) << "Failed to open " << argv[optind];
     return -1;
   }
   auto program_str = ReadFully(program_fd.get());
@@ -140,10 +176,23 @@ int main(int argc, char* argv[]) {
       WriteFileDescriptor(STDERR_FILENO, "LIMITE DE INSTRUCCIONES DEJA_ZUMBADOR");
       break;
   }
+  int output_fd = STDOUT_FILENO;
+  if (output_file) {
+      output_fd = open(output_file->c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+      if (output_fd == -1) {
+          perror("Error opening output file");
+          return 1;
+      }
+  }
+
   if (dump_result)
-    world->DumpResult(result);
+    world->DumpResult(result, output_fd);
   else
-    world->Dump();
+    world->Dump(output_fd);
+
+  if (output_fd != STDOUT_FILENO) {
+    close(output_fd);
+  }
 
   return static_cast<int32_t>(result);
 }

--- a/world.cpp
+++ b/world.cpp
@@ -217,8 +217,8 @@ std::optional<World> World::Parse(int fd) {
     return std::make_optional<World>(std::move(world));
   }
 
-  void World::Dump() const {
-    xml::Writer writer(STDOUT_FILENO);
+  void World::Dump(int fd) const {
+    xml::Writer writer(fd);
 
     auto ejecucion = writer.CreateElement("ejecucion");
     {
@@ -375,9 +375,9 @@ std::optional<World> World::Parse(int fd) {
     }
   }
 
-  void World::DumpResult(karel::RunResult result) const {
+  void World::DumpResult(karel::RunResult result, int fd) const {
     {
-      xml::Writer writer(STDOUT_FILENO);
+      xml::Writer writer(fd);
 
       auto resultados = writer.CreateElement("resultados");
 

--- a/world.h
+++ b/world.h
@@ -23,9 +23,9 @@ namespace karel {
 
             static std::optional<World> Parse(int fd);
 
-            void Dump() const;
+            void Dump(int fd) const;
 
-            void DumpResult(karel::RunResult result) const;
+            void DumpResult(karel::RunResult result, int fd) const;
 
             karel::Runtime* runtime();
 


### PR DESCRIPTION
Added more options, previously the only available function was --dump

Arguments:
  <bytecode-file>          The Karel bytecode file to execute. This is a required argument.

Options:
  -i, --input <input-path>    Specify a file to read the world input from. If not provided, the program reads from stdin.
  -o, --output <output-path>  Specify a file to write the world output to. If not provided, the program writes to stdout.
  -d, --dump {world|result}   Set the output type:
                                - result: (default) Outputs the program's result.
                                - world: Outputs the world input.
  -e, --expect-version <major.minor>
                              Specify the required version of the program (major.minor).
                              If the version does not match, the program exits with an error.

Example:
  ./program mycode.kx -i world.in -o world.out -d world -e 3.1
  ./program mycode.kx -d result